### PR TITLE
fix(security): resolve high-severity CodeQL alerts

### DIFF
--- a/src/routes/ai-batch-optimized.ts
+++ b/src/routes/ai-batch-optimized.ts
@@ -33,10 +33,9 @@ const config = getAIConfig();
 
 // 🔍 DEBUG: Check API key status
 console.log('🔑 API Key Status Check:');
+// presence only — never log key-derived data (length, prefix, etc.) - embracingearth.space
 console.log('🔑 OPENAI_API_KEY exists:', !!process.env.OPENAI_API_KEY);
-console.log('🔑 OPENAI_API_KEY length:', process.env.OPENAI_API_KEY?.length || 0);
 console.log('🔑 Config apiKey exists:', !!config.apiKey);
-console.log('🔑 Config apiKey length:', config.apiKey?.length || 0);
 
 let batchEngine: BatchProcessingEngine;
 let referenceParser: ReferenceDataParser;

--- a/src/routes/log-routes.ts
+++ b/src/routes/log-routes.ts
@@ -4,6 +4,34 @@ import { LogViewer } from '../utils/LogViewer';
 
 const router = express.Router();
 
+// Allowlist for the user-supplied ?timeRange query param. Validating at the
+// route boundary lets us return 400 (client error) for bad input instead of
+// letting APILogger's internal guard throw and surface as a 500 — a generic 500
+// misclassifies a client mistake as a server fault and pollutes error
+// monitoring. APILogger keeps its own allowlist as defense-in-depth.
+// (CodeRabbit #4) embracingearth.space
+const ALLOWED_TIME_RANGES = ['hour', 'day', 'week'] as const;
+type TimeRange = (typeof ALLOWED_TIME_RANGES)[number];
+
+// Absent → default 'day'. Present-but-invalid → null (caller returns 400).
+function parseTimeRange(raw: unknown): TimeRange | null {
+  if (raw === undefined) return 'day';
+  return (ALLOWED_TIME_RANGES as readonly string[]).includes(raw as string)
+    ? (raw as TimeRange)
+    : null;
+}
+
+// res typed as any to match this repo's existing handler convention (req: any,
+// res: any) and avoid depending on the express type namespace here.
+function invalidTimeRange(res: any) {
+  return res.status(400).json({
+    success: false,
+    error: 'Invalid timeRange',
+    message: `timeRange must be one of: ${ALLOWED_TIME_RANGES.join(', ')}`,
+    timestamp: new Date().toISOString(),
+  });
+}
+
 /**
  * 📊 GET /api/logs/dashboard
  * 
@@ -11,9 +39,10 @@ const router = express.Router();
  */
 router.get('/dashboard', async (req, res) => {
   try {
-    const timeRange = req.query.timeRange as 'hour' | 'day' | 'week' || 'day';
+    const timeRange = parseTimeRange(req.query.timeRange);
+    if (timeRange === null) return invalidTimeRange(res);
     const report = apiLogger.generatePerformanceReport(timeRange);
-    
+
     res.json({
       success: true,
       data: report,
@@ -112,7 +141,8 @@ router.get('/detail/:requestId', async (req, res) => {
  */
 router.get('/analytics', async (req, res) => {
   try {
-    const timeRange = req.query.timeRange as 'hour' | 'day' | 'week' || 'day';
+    const timeRange = parseTimeRange(req.query.timeRange);
+    if (timeRange === null) return invalidTimeRange(res);
     const analytics = LogViewer.generateAnalytics(timeRange);
     
     res.json({

--- a/src/routes/log-routes.ts
+++ b/src/routes/log-routes.ts
@@ -49,7 +49,9 @@ router.get('/dashboard', async (req, res) => {
       timestamp: new Date().toISOString()
     });
   } catch (error: any) {
-    res.status(500).json({
+    // Honor a typed statusCode (e.g. APILogger's 400 ValidationError) so client
+    // errors aren't reported as 500s. embracingearth.space
+    res.status(typeof error?.statusCode === 'number' ? error.statusCode : 500).json({
       success: false,
       error: 'Failed to generate dashboard',
       message: error.message,
@@ -151,7 +153,7 @@ router.get('/analytics', async (req, res) => {
       timestamp: new Date().toISOString()
     });
   } catch (error: any) {
-    res.status(500).json({
+    res.status(typeof error?.statusCode === 'number' ? error.statusCode : 500).json({
       success: false,
       error: 'Failed to generate analytics',
       message: error.message,

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -5,11 +5,25 @@
  */
 
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { logger } from '../services/LoggingService';
 import * as fs from 'fs';
 import * as path from 'path';
 
 const router = Router();
+
+// 🔐 SECURITY: Rate limit filesystem-backed log endpoints (CodeQL js/missing-rate-limiting) - embracingearth.space
+const logsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: {
+    error: 'Too many log API requests, please try again later.',
+    retryAfter: '15 minutes'
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+router.use(logsLimiter);
 
 // 🔐 SECURITY: Admin authentication middleware
 const requireAdminAuth = (req: any, res: any, next: any) => {

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -16,6 +16,11 @@ const router = Router();
 const logsLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100, // Limit each IP to 100 requests per windowMs
+  // Machine-readable retry timing is emitted via the standard RateLimit-*
+  // headers (standardHeaders: true → RateLimit-Reset). The retryAfter field
+  // below is only a human-readable hint in the JSON body; with
+  // legacyHeaders: false it is intentionally NOT sent as a Retry-After header.
+  // (CodeRabbit #4) embracingearth.space
   message: {
     error: 'Too many log API requests, please try again later.',
     retryAfter: '15 minutes'

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,8 +57,22 @@ const app = express();
 // embracingearth.space
 const TRUST_PROXY = process.env.TRUST_PROXY;
 if (TRUST_PROXY !== undefined && TRUST_PROXY.trim() !== '') {
-  const hops = Number(TRUST_PROXY);
-  app.set('trust proxy', Number.isInteger(hops) ? hops : TRUST_PROXY.trim());
+  const trimmed = TRUST_PROXY.trim();
+  const hops = Number(trimmed);
+  // Express treats boolean true/false differently from the strings 'true'/'false'
+  // — a string is parsed as an IP/subnet list and silently trusts nothing — so map
+  // the common boolean-like values explicitly; numbers become the hop count, and
+  // anything else (e.g. 'loopback', a subnet) passes through. (CodeRabbit #4)
+  // embracingearth.space
+  const trustProxy =
+    trimmed.toLowerCase() === 'true'
+      ? true
+      : trimmed.toLowerCase() === 'false'
+        ? false
+        : Number.isInteger(hops)
+          ? hops
+          : trimmed;
+  app.set('trust proxy', trustProxy);
 }
 
 const PORT = process.env.AI_PORT || 3002;

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,21 @@ import logRoutes from './routes/logs';
 import taxRoutes from './routes/ai-tax';
 
 const app = express();
+
+// 🔐 SECURITY/OPS: behind a reverse proxy (Fly.io edge, nginx, Cloudflare) the
+// per-IP rate limiter on /logs only works if req.ip is the real client IP — else
+// express-rate-limit buckets every client under the proxy's single IP. This is
+// env-driven on purpose: blindly trusting X-Forwarded-For lets a client spoof
+// their IP and evade the limiter, so the default (unset) trusts nothing. Set
+// TRUST_PROXY to the number of proxy hops in front of this service (Fly = 1), or
+// an Express-recognized value ('loopback', a subnet, 'true'). (CodeRabbit #4)
+// embracingearth.space
+const TRUST_PROXY = process.env.TRUST_PROXY;
+if (TRUST_PROXY !== undefined && TRUST_PROXY.trim() !== '') {
+  const hops = Number(TRUST_PROXY);
+  app.set('trust proxy', Number.isInteger(hops) ? hops : TRUST_PROXY.trim());
+}
+
 const PORT = process.env.AI_PORT || 3002;
 // embracingearth.space - CF Origin Lock configuration (env-driven)
 const ORIGIN_LOCK_ENABLED = process.env.ENFORCE_CF_ORIGIN_LOCK === 'true';

--- a/src/services/AIOrchestrator.ts
+++ b/src/services/AIOrchestrator.ts
@@ -708,7 +708,8 @@ export class AIOrchestrator {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       const errorStack = error instanceof Error ? error.stack : 'No stack trace available';
       
-      console.error('❌ executeWorkflowSync failed for ' + workflowName, {
+      // user-derived value passed as arg, not format string (CodeQL js/tainted-format-string) - embracingearth.space
+      console.error('❌ executeWorkflowSync failed for %s', workflowName, {
         error: errorMessage,
         stack: errorStack
       });
@@ -763,13 +764,15 @@ export class AIOrchestrator {
       
       // At least one of description or merchant must be present
       if (!description && !merchant) {
-        console.warn(`⚠️ AIOrchestrator: Transaction ${id || index} missing both description and merchant:`, transaction);
+        // user-derived id passed as arg, not format string - embracingearth.space
+        console.warn('⚠️ AIOrchestrator: Transaction %s missing both description and merchant:', id || index, transaction);
         return false;
       }
 
       // Amount should be a number
       if (amount !== undefined && typeof amount !== 'number') {
-        console.warn(`⚠️ AIOrchestrator: Transaction ${id || index} has invalid amount:`, transaction);
+        // user-derived id passed as arg, not format string - embracingearth.space
+        console.warn('⚠️ AIOrchestrator: Transaction %s has invalid amount:', id || index, transaction);
         return false;
       }
 

--- a/src/services/APILogger.ts
+++ b/src/services/APILogger.ts
@@ -231,7 +231,14 @@ export class APILogger {
     // before it reaches a filesystem path; fail closed, never rewrite - embracingearth.space
     const allowedTimeRanges: ReadonlyArray<string> = ['hour', 'day', 'week'];
     if (!allowedTimeRanges.includes(timeRange)) {
-      throw new Error('Invalid timeRange: expected one of hour, day, week');
+      // Typed as a 400 client error (not a generic Error → 500) so the route and
+      // error monitoring can tell bad user input apart from a server fault. The
+      // log routes also pre-validate; this is defense-in-depth. (CodeRabbit #4)
+      // embracingearth.space
+      const err: any = new Error('Invalid timeRange: expected one of hour, day, week');
+      err.statusCode = 400;
+      err.name = 'ValidationError';
+      throw err;
     }
     const logs = this.readLogs(timeRange);
     

--- a/src/services/APILogger.ts
+++ b/src/services/APILogger.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import crypto from 'crypto'; // CSPRNG for request/session IDs - embracingearth.space
 
 export interface APILogEntry {
   timestamp: string;
@@ -129,7 +130,7 @@ export class APILogger {
     console.log(`   💰 Cost Estimate: $${(metadata.costEstimate || 0).toFixed(4)}`);
     console.log(`   📊 Transactions: ${metadata.transactionCount || 1}`);
     console.log(`   📝 Prompt Length: ${prompt.length} chars`);
-    console.log(`   🔑 API Key: ${config.apiKey ? config.apiKey.substring(0, 7) + '...' : 'NOT SET'}\n`);
+    console.log(`   🔑 API Key: ${config.apiKey ? '[REDACTED]' : 'NOT SET'}\n`); // never log key material - embracingearth.space
     
     return requestId;
   }
@@ -226,6 +227,12 @@ export class APILogger {
    * 📊 Generate Performance Report
    */
   generatePerformanceReport(timeRange: 'hour' | 'day' | 'week' = 'day'): any {
+    // 🔐 SECURITY: timeRange can arrive from user input (req.query cast) — allowlist it
+    // before it reaches a filesystem path; fail closed, never rewrite - embracingearth.space
+    const allowedTimeRanges: ReadonlyArray<string> = ['hour', 'day', 'week'];
+    if (!allowedTimeRanges.includes(timeRange)) {
+      throw new Error('Invalid timeRange: expected one of hour, day, week');
+    }
     const logs = this.readLogs(timeRange);
     
     const report = {
@@ -242,7 +249,14 @@ export class APILogger {
     };
 
     // Save report to file
-    const reportFile = path.join(this.logDir, `performance-report-${timeRange}.json`);
+    // 🔐 SECURITY: containment check — resolved path must stay inside the log directory
+    // (path.relative guard avoids startsWith sibling-prefix bugs) - embracingearth.space
+    const resolvedBase = path.resolve(this.logDir);
+    const reportFile = path.resolve(resolvedBase, `performance-report-${timeRange}.json`);
+    const relative = path.relative(resolvedBase, reportFile);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('Invalid report path: escapes log directory');
+    }
     fs.writeFileSync(reportFile, JSON.stringify(report, null, 2));
     
     return report;
@@ -589,7 +603,7 @@ export class APILogger {
    */
   private generateRequestId(): string {
     const timestamp = Date.now();
-    const random = Math.random().toString(36).substring(2, 8);
+    const random = crypto.randomBytes(3).toString('hex'); // CSPRNG, 6 chars - embracingearth.space
     return `req_${timestamp}_${random}`;
   }
 
@@ -598,7 +612,7 @@ export class APILogger {
    */
   private generateSessionId(): string {
     const timestamp = Date.now();
-    const random = Math.random().toString(36).substring(2, 10);
+    const random = crypto.randomBytes(4).toString('hex'); // CSPRNG, 8 chars - embracingearth.space
     return `session_${timestamp}_${random}`;
   }
 }

--- a/src/services/BatchProcessingEngine.ts
+++ b/src/services/BatchProcessingEngine.ts
@@ -14,6 +14,7 @@
  * - Provides comprehensive analytics and insights
  */
 
+import crypto from 'crypto'; // CSPRNG for request IDs + hashing - embracingearth.space
 import { ReferenceDataParser, TransactionAnalysisResult } from './ReferenceDataParser';
 import { TransactionClassificationAIAgent } from './TransactionClassificationAIAgent';
 import { AIConfig } from '../types/ai-types';
@@ -104,8 +105,7 @@ export class BatchProcessingEngine {
     
     // 🔍 DEBUG: Check API key and AI agent initialization
     console.log('🔧 BatchProcessingEngine Constructor:');
-    console.log('🔧 Config apiKey exists:', !!config.apiKey);
-    console.log('🔧 Config apiKey length:', config.apiKey?.length || 0);
+    console.log('🔧 Config apiKey exists:', !!config.apiKey); // presence only — never log key-derived data - embracingearth.space
     
     // Initialize AI agent if API key is available
     if (config.apiKey) {
@@ -119,7 +119,6 @@ export class BatchProcessingEngine {
 
   // Enterprise: Generate consistent hash for response tracking and caching
   private generateResponseHash(transactions: any[], userContext: string): string {
-    const crypto = require('crypto');
     const normalizedInput = {
       transactions: transactions.map(t => ({
         desc: t.description?.toLowerCase().trim(),
@@ -159,7 +158,7 @@ export class BatchProcessingEngine {
     options: BatchProcessingOptions = this.getDefaultOptions()
   ): Promise<BatchProcessingResult> {
     const startTime = Date.now();
-    const requestId = `batch-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const requestId = `batch-${Date.now()}-${crypto.randomBytes(5).toString('hex')}`; // CSPRNG - embracingearth.space
     
     logger.info('BatchProcessingEngine', `Starting batch processing of ${transactions.length} transactions`, {
       transactionCount: transactions.length,
@@ -503,7 +502,7 @@ export class BatchProcessingEngine {
     selectedCategories: string[],
     context: AIDataContext
   ): Promise<any[]> {
-    const requestId = `categorize-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const requestId = `categorize-${Date.now()}-${crypto.randomBytes(5).toString('hex')}`; // CSPRNG - embracingearth.space
     const startTime = Date.now();
     
     // Log the API request with actual prompt


### PR DESCRIPTION
Resolves all 14 open HIGH-severity CodeQL alerts on `main`. Minimal, behavior-preserving edits; `tsc --noEmit` clean (0 errors, matching a 0-error pristine baseline).

## Alert → Fix

| Alert | Rule | Location | Fix |
|---|---|---|---|
| #14 | js/path-injection | `src/services/APILogger.ts:246` | `generatePerformanceReport(timeRange)` is reachable from `req.query.timeRange` (cast in `log-routes.ts:14`). Added fail-closed allowlist (`hour\|day\|week` → throw on anything else) **and** containment guard: resolve against the log dir, reject if `path.relative(base, resolved)` starts with `..` or is absolute. Never silently rewrites. |
| #13 | js/clear-text-logging | `src/services/BatchProcessingEngine.ts:108` | Removed `apiKey.length` log line; presence-only boolean log retained. |
| #12 | js/clear-text-logging | `src/services/APILogger.ts:132` | No longer logs the key's first 7 chars; logs `[REDACTED]` / `NOT SET`. |
| #11 | js/clear-text-logging | `src/routes/ai-batch-optimized.ts:39` | Removed `config.apiKey.length` log line; presence-only log retained. |
| #10 | js/clear-text-logging | `src/routes/ai-batch-optimized.ts:37` | Removed `OPENAI_API_KEY.length` log line; presence-only log retained. |
| #9, #8, #7 | js/missing-rate-limiting | `src/routes/logs.ts:191,123,69` | No global limiter exists in `server.ts`; `express-rate-limit@^7` is already a dependency (used in `ai-tax.ts`). Added a scoped `router.use(logsLimiter)` (100 req / 15 min / IP, same style as the existing `taxAnalysisLimiter`) covering all filesystem-backed log endpoints. |
| #6, #5 | js/insecure-randomness | sinks `LoggingService.ts:106,219`; **source** `BatchProcessingEngine.ts:162` | Replaced `Math.random()` request-ID suffix with `crypto.randomBytes(5).toString('hex')`. Also fixed the identical un-flagged pattern at `BatchProcessingEngine.ts:506` to prevent a re-flag via the `logApiRequest` path. |
| #4 | js/insecure-randomness | sink `APILogger.ts:60`; **source** `APILogger.ts:601` | `generateSessionId()` now uses `crypto.randomBytes(4).toString('hex')` (8 chars, matching prior length). Also hardened the sibling `generateRequestId()` (`APILogger.ts:592`, same pattern) with `randomBytes(3)` (6 chars, matching prior length). |

Notes:
- IDs remain opaque `prefix_timestamp_random` strings — format/length compatible with existing consumers (log fields only; nothing parses the suffix).
- Removed a redundant method-local `require('crypto')` in `BatchProcessingEngine.generateResponseHash` superseded by the new top-level import (no behavior change).
- Invalid `timeRange` now surfaces as a 500 via the existing `try/catch` in `log-routes.ts` instead of writing an attacker-influenced path.

## Verification
- Pristine baseline `tsc --noEmit` on `main` (3511089): **0 errors**
- Post-fix `tsc --noEmit`: **0 errors** (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Honor TRUST_PROXY to better determine client IPs behind reverse proxies.

* **Bug Fixes**
  * Add rate limiting to logs endpoint (100 requests / 15 minutes per IP).
  * Reject invalid log timeRange queries with 400 and whitelist allowed values.
  * Surface proper status codes for log report errors when available.

* **Chores**
  * Stop printing API key details in logs.
  * Use cryptographically secure IDs for requests/sessions.
  * Validate performance-report inputs and enforce safe report file paths.

* **Style**
  * Standardize logging formatting to avoid unsafe string interpolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->